### PR TITLE
fix: ensure Claude workflows checkout PR branch correctly

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -25,9 +25,17 @@ jobs:
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
+      - name: Get PR ref
+        id: pr-ref
+        if: github.event_name == 'issue_comment' && github.event.issue.pull_request
+        run: |
+          PR_NUMBER=${{ github.event.issue.number }}
+          echo "ref=refs/pull/${PR_NUMBER}/head" >> $GITHUB_OUTPUT
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          ref: ${{ steps.pr-ref.outputs.ref || github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 1
 
       - name: Check for package.json


### PR DESCRIPTION
## Summary
- Fix GitHub Actions workflow to checkout PR branch when triggered by PR comments
- Add conditional Node.js setup to handle branches with/without package.json

## Problem
When @mentioning Claude in a PR comment, the workflow was checking out `main` instead of the PR branch, causing it to fail when looking for `package-lock.json`.

## Solution
1. **Detect PR comments**: Added logic to detect when workflow is triggered by `issue_comment` on a PR
2. **Checkout PR branch**: Explicitly checkout `refs/pull/{number}/head` for PR comments
3. **Conditional setup**: Made Node.js setup conditional on `package.json` existence as a safety measure

## Test plan
- [ ] @mention Claude on a PR targeting feature/initial-implementation
- [ ] Verify workflow checks out the PR branch (not main)
- [ ] Verify npm dependencies install successfully
- [ ] Verify Claude can run npm commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)