### PR TITLE
Group Dependabot updates for related packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,22 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - 'dependencies'
+    groups:
+      # Group AWS SDK packages together (they have strict peer dependencies)
+      aws-sdk:
+        patterns:
+          - '@aws-sdk/*'
+      # Group TypeScript ESLint packages together
+      typescript-eslint:
+        patterns:
+          - '@typescript-eslint/*'
+      # Group ESLint-related packages
+      eslint:
+        patterns:
+          - 'eslint'
+          - 'eslint-*'
+        exclude-patterns:
+          - '@typescript-eslint/*'
 
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: 'github-actions'


### PR DESCRIPTION
## Summary
- Configure Dependabot to group related dependency updates into single PRs
- Prevents peer dependency conflicts between AWS SDK packages
- Groups TypeScript ESLint packages together
- Groups other ESLint-related packages

## Changes
Added `groups` configuration to `.github/dependabot.yml`:
- **aws-sdk**: Groups all `@aws-sdk/*` packages together
- **typescript-eslint**: Groups all `@typescript-eslint/*` packages together
- **eslint**: Groups ESLint and `eslint-*` packages (excluding TypeScript ESLint)

## Why?
The current setup creates separate PRs for each dependency, which causes issues:
- AWS SDK packages have strict peer dependencies (e.g., `@aws-sdk/lib-storage` requires exact version match of `@aws-sdk/client-s3`)
- Separate PRs fail CI due to `npm ci` peer dependency conflicts
- Grouped updates will install and test all related packages together

## Next Steps
After merging:
1. Close existing Dependabot PRs (#6-16)
2. Wait for next scheduled run (Saturday 9am) or manually trigger
3. New grouped PRs will avoid peer dependency conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)