### PR TITLE
fix(deps): merge eslint groups in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,16 +15,12 @@ updates:
       aws-sdk:
         patterns:
           - '@aws-sdk/*'
-      # Group TypeScript ESLint packages together
-      typescript-eslint:
-        patterns:
-          - '@typescript-eslint/*'
-      # Group ESLint-related packages
+      # Group all ESLint-related packages together (including TypeScript ESLint)
+      # This prevents peer dependency conflicts between eslint and @typescript-eslint/*
       eslint:
         patterns:
           - 'eslint'
           - 'eslint-*'
-        exclude-patterns:
           - '@typescript-eslint/*'
 
   # Maintain dependencies for GitHub Actions


### PR DESCRIPTION
## Summary
Fixes peer dependency conflicts in Dependabot updates by merging the separate `eslint` and `typescript-eslint` groups into a single unified group.

## Problem
PR #20 failed because Dependabot updated `eslint` to v10.0.0 independently, but `@typescript-eslint/eslint-plugin@8.54.0` only supports `eslint@^8.57.0 || ^9.0.0`. The separate groups allowed incompatible updates.

## Solution
Combined both groups so all ESLint-related packages (`eslint`, `eslint-*`, `@typescript-eslint/*`) update atomically, preventing peer dependency conflicts.

## Testing
- Configuration change only - no code changes
- Will prevent future PRs like #20 that break peer dependencies
- Next Dependabot run will create a single PR for all ESLint packages together

Fixes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)