### PR TITLE
Fix Docker build failure in Dokploy deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,6 +15,8 @@ dist
 
 # Data directory (will be mounted as volume)
 data/
+# But include pricing.json.example for bundling in the image
+!data/pricing.json.example
 
 # Git
 .git


### PR DESCRIPTION
## Summary
- Add exception to `.dockerignore` to include `data/pricing.json.example` in Docker build context
- Fixes deployment error: `"/data/pricing.json.example": not found`

## Details
The `.dockerignore` file was excluding the entire `data/` directory, preventing the Dockerfile from copying `data/pricing.json.example` during build. This caused Dokploy deployments to fail.

The fix adds `!data/pricing.json.example` to create an exception while still excluding the rest of the data directory (which should be mounted as a volume at runtime).

## Test plan
- [ ] Verify Docker build succeeds locally: `docker build -t unread-cast .`
- [ ] Deploy to Dokploy and confirm the build completes without errors
- [ ] Verify `/app/pricing.json` exists in the running container

🤖 Generated with [Claude Code](https://claude.com/claude-code)