### PR TITLE
Fix ffmpeg AAC format error in audio merging

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "*.{ts,js}": [
       "prettier --write",
       "eslint --fix",
-      "npm test -- --run"
+      "npm test -- --run --passWithNoTests"
     ]
   }
 }

--- a/src/services/ffmpeg.ts
+++ b/src/services/ffmpeg.ts
@@ -79,7 +79,7 @@ export function createFfmpegService(): FfmpegService {
         '-c:a',
         'copy', // Copy audio codec (no re-encoding)
         '-f',
-        'aac', // Output format
+        'adts', // Output format (ADTS is the standard container for AAC audio)
         'pipe:1', // Write to stdout
       ];
 


### PR DESCRIPTION
## Summary
Fixes the production error when processing podcast entries: `Requested output format 'aac' is not known`

## Changes
1. **Fix ffmpeg output format** (`src/services/ffmpeg.ts`):
   - Changed output format from `'aac'` to `'adts'` when streaming AAC audio
   - `aac` is not a valid ffmpeg muxer format; `adts` (Audio Data Transport Stream) is the correct container for streaming AAC audio via pipes

2. **Fix pre-commit hook** (`package.json`):
   - Added `--passWithNoTests` flag to vitest in lint-staged configuration
   - Prevents hook failure when modifying non-test files

## Technical Details
- The audio codec remains unchanged (`-c:a copy`)
- ADTS is the standard container for AAC audio streaming
- All existing uploaded audio files remain valid
- No changes needed to R2 upload, RSS feeds, or content-type headers

## Testing
- ✅ All 86 tests pass
- ✅ Pre-commit hooks pass successfully
- ✅ Ready for production deployment

## Verification Plan
1. Deploy to production
2. Submit test entry via API
3. Monitor logs for successful processing without ffmpeg errors
4. Verify audio playback in podcast app

🤖 Generated with [Claude Code](https://claude.ai/code)