### PR TITLE
feat: Add Medium RSS feed support to bypass Cloudflare blocking

### DIFF
--- a/src/processing/fetcher.ts
+++ b/src/processing/fetcher.ts
@@ -1,5 +1,134 @@
 // src/processing/fetcher.ts
+import { JSDOM } from 'jsdom';
+
+interface MediumUrlInfo {
+  isMedium: boolean;
+  username?: string;
+  articleSlug?: string;
+  rssUrl?: string;
+}
+
+/**
+ * Detects if a URL is a Medium article and extracts metadata
+ */
+function detectMediumUrl(url: string): MediumUrlInfo {
+  try {
+    const urlObj = new URL(url);
+    const hostname = urlObj.hostname;
+    const pathname = urlObj.pathname;
+
+    const pathParts = pathname.split('/').filter(Boolean);
+    const articleSlug = pathParts[pathParts.length - 1] || '';
+
+    // Personal blog: username.medium.com
+    if (hostname.endsWith('.medium.com')) {
+      const username = hostname.replace('.medium.com', '');
+      return {
+        isMedium: true,
+        username,
+        articleSlug,
+        rssUrl: `https://medium.com/feed/@${username}`,
+      };
+    }
+
+    // Medium publication: medium.com/@username
+    if (hostname === 'medium.com' && pathname.startsWith('/@')) {
+      const username = pathParts[0]?.replace('@', '') || '';
+      return {
+        isMedium: true,
+        username,
+        articleSlug,
+        rssUrl: `https://medium.com/feed/@${username}`,
+      };
+    }
+
+    return { isMedium: false };
+  } catch {
+    return { isMedium: false };
+  }
+}
+
+/**
+ * Extracts article content from Medium RSS feed XML
+ */
+function extractContentFromRss(rssXml: string, articleSlug: string): string {
+  const dom = new JSDOM(rssXml, { contentType: 'text/xml' });
+  const doc = dom.window.document;
+
+  const items = doc.querySelectorAll('item');
+
+  if (items.length === 0) {
+    throw new Error('No items found in Medium RSS feed');
+  }
+
+  // Find item by matching article slug in link/guid
+  for (const item of items) {
+    const link = item.querySelector('link')?.textContent?.trim() || '';
+    const guid = item.querySelector('guid')?.textContent?.trim() || '';
+
+    if (link.includes(articleSlug) || guid.includes(articleSlug)) {
+      // Get all elements and find one with localName 'encoded' (works regardless of namespace prefix)
+      let htmlContent = '';
+
+      const allElements = item.getElementsByTagName('*');
+      for (let i = 0; i < allElements.length; i++) {
+        const el = allElements[i];
+        if (el.localName === 'encoded') {
+          htmlContent = el.textContent || '';
+          break;
+        }
+      }
+
+      if (!htmlContent || htmlContent.length < 100) {
+        throw new Error(`No content found in RSS item for article: ${articleSlug}`);
+      }
+
+      // Wrap for Readability compatibility
+      return `
+        <html>
+          <head><title>Medium Article</title></head>
+          <body>${htmlContent}</body>
+        </html>
+      `;
+    }
+  }
+
+  throw new Error(`Article not found in Medium RSS feed: ${articleSlug}`);
+}
+
+/**
+ * Fetches Medium article content via RSS feed
+ */
+async function fetchFromMediumRss(url: string): Promise<string> {
+  const mediumInfo = detectMediumUrl(url);
+
+  if (!mediumInfo.isMedium || !mediumInfo.rssUrl || !mediumInfo.articleSlug) {
+    throw new Error(`Invalid Medium URL: ${url}`);
+  }
+
+  const response = await fetch(mediumInfo.rssUrl, {
+    headers: {
+      'User-Agent': 'Mozilla/5.0 (compatible; UnreadCast/1.0; +https://github.com/unread-cast)',
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch Medium RSS feed ${mediumInfo.rssUrl}: ${response.status}`);
+  }
+
+  const rssXml = await response.text();
+  return extractContentFromRss(rssXml, mediumInfo.articleSlug);
+}
+
 export async function fetchHtml(url: string): Promise<string> {
+  const mediumInfo = detectMediumUrl(url);
+
+  if (mediumInfo.isMedium && mediumInfo.rssUrl) {
+    // Use RSS for Medium URLs, fail immediately if RSS fetch fails
+    return await fetchFromMediumRss(url);
+  }
+
+  // Existing direct fetch logic for non-Medium URLs
   const response = await fetch(url, {
     headers: {
       'User-Agent': 'Mozilla/5.0 (compatible; UnreadCast/1.0; +https://github.com/unread-cast)',

--- a/tests/processing/fetcher.test.ts
+++ b/tests/processing/fetcher.test.ts
@@ -2,31 +2,358 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 describe('fetcher', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.resetAllMocks();
+    // Clear module cache to ensure fresh imports
+    vi.resetModules();
   });
 
-  it('should fetch HTML from URL', async () => {
-    const mockHtml = '<html><body>Test content</body></html>';
-    global.fetch = vi.fn().mockResolvedValue({
-      ok: true,
-      text: () => Promise.resolve(mockHtml),
+  describe('non-Medium URLs', () => {
+    it('should fetch HTML from URL', async () => {
+      const mockHtml = '<html><body>Test content</body></html>';
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve(mockHtml),
+      });
+
+      const { fetchHtml } = await import('../../src/processing/fetcher.js');
+      const result = await fetchHtml('https://example.com');
+
+      expect(result).toBe(mockHtml);
     });
 
-    const { fetchHtml } = await import('../../src/processing/fetcher.js');
-    const result = await fetchHtml('https://example.com');
+    it('should throw on fetch error', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+      });
 
-    expect(result).toBe(mockHtml);
+      const { fetchHtml } = await import('../../src/processing/fetcher.js');
+
+      await expect(fetchHtml('https://example.com')).rejects.toThrow('404');
+    });
   });
 
-  it('should throw on fetch error', async () => {
-    global.fetch = vi.fn().mockResolvedValue({
-      ok: false,
-      status: 404,
+  describe('Medium RSS support', () => {
+    const createMockRssFeed = (articleSlug: string, content: string) =>
+      `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/">
+  <channel>
+    <title>Test Feed</title>
+    <item>
+      <title>Test Article</title>
+      <link>https://username.medium.com/${articleSlug}</link>
+      <guid>https://username.medium.com/${articleSlug}</guid>
+      <content:encoded><![CDATA[${content}]]></content:encoded>
+    </item>
+  </channel>
+</rss>`;
+
+    describe('URL detection', () => {
+      it('should detect personal blog Medium URLs', async () => {
+        const articleUrl = 'https://steve-yegge.medium.com/software-survival-3-0-97a2a6255f7b';
+        const rssUrl = 'https://medium.com/feed/@steve-yegge';
+        const mockContent =
+          '<div><h1>Test Article</h1><p>Article content goes here with enough text to pass validation.</p></div>';
+
+        global.fetch = vi.fn().mockImplementation((url: string) => {
+          if (url === rssUrl) {
+            return Promise.resolve({
+              ok: true,
+              text: () =>
+                Promise.resolve(
+                  createMockRssFeed('software-survival-3-0-97a2a6255f7b', mockContent)
+                ),
+            });
+          }
+          return Promise.reject(new Error('Unexpected URL'));
+        });
+
+        const { fetchHtml } = await import('../../src/processing/fetcher.js');
+        const result = await fetchHtml(articleUrl);
+
+        expect(result).toContain(mockContent);
+        expect(global.fetch).toHaveBeenCalledWith(rssUrl, expect.any(Object));
+      });
+
+      it('should detect publication Medium URLs', async () => {
+        const articleUrl = 'https://medium.com/@username/test-article-12345';
+        const rssUrl = 'https://medium.com/feed/@username';
+        const mockContent =
+          '<div><h1>Publication Article</h1><p>This is a test publication article with sufficient content.</p></div>';
+
+        global.fetch = vi.fn().mockImplementation((url: string) => {
+          if (url === rssUrl) {
+            return Promise.resolve({
+              ok: true,
+              text: () => Promise.resolve(createMockRssFeed('test-article-12345', mockContent)),
+            });
+          }
+          return Promise.reject(new Error('Unexpected URL'));
+        });
+
+        const { fetchHtml } = await import('../../src/processing/fetcher.js');
+        const result = await fetchHtml(articleUrl);
+
+        expect(result).toContain(mockContent);
+        expect(global.fetch).toHaveBeenCalledWith(rssUrl, expect.any(Object));
+      });
+
+      it('should not treat non-Medium URLs as Medium', async () => {
+        const mockHtml = '<html><body>Regular content</body></html>';
+        global.fetch = vi.fn().mockResolvedValue({
+          ok: true,
+          text: () => Promise.resolve(mockHtml),
+        });
+
+        const { fetchHtml } = await import('../../src/processing/fetcher.js');
+        const result = await fetchHtml('https://example.com/article');
+
+        expect(result).toBe(mockHtml);
+        expect(global.fetch).toHaveBeenCalledWith(
+          'https://example.com/article',
+          expect.any(Object)
+        );
+      });
     });
 
-    const { fetchHtml } = await import('../../src/processing/fetcher.js');
+    describe('RSS parsing', () => {
+      it('should extract content from RSS feed', async () => {
+        const articleUrl = 'https://username.medium.com/test-article-abc123';
+        const mockContent =
+          '<div><h1>Article Title</h1><p>Full article content with plenty of text to meet minimum requirements.</p></div>';
 
-    await expect(fetchHtml('https://example.com')).rejects.toThrow('404');
+        global.fetch = vi.fn().mockResolvedValue({
+          ok: true,
+          text: () => Promise.resolve(createMockRssFeed('test-article-abc123', mockContent)),
+        });
+
+        const { fetchHtml } = await import('../../src/processing/fetcher.js');
+        const result = await fetchHtml(articleUrl);
+
+        expect(result).toContain(mockContent);
+        expect(result).toContain('<html>');
+        expect(result).toContain('<body>');
+      });
+
+      it('should match article by slug in link', async () => {
+        const articleUrl = 'https://username.medium.com/my-article-slug';
+        const mockContent =
+          '<div><p>Content that is definitely long enough to pass the validation check in the parser with extra words.</p></div>';
+
+        global.fetch = vi.fn().mockResolvedValue({
+          ok: true,
+          text: () => Promise.resolve(createMockRssFeed('my-article-slug', mockContent)),
+        });
+
+        const { fetchHtml } = await import('../../src/processing/fetcher.js');
+        const result = await fetchHtml(articleUrl);
+
+        expect(result).toContain(mockContent);
+      });
+
+      it('should match article by slug in guid', async () => {
+        const articleUrl = 'https://username.medium.com/my-article-slug';
+        const mockContent =
+          '<div><p>Content that is definitely long enough to pass the validation check in the parser with extra words.</p></div>';
+        const rssXml = createMockRssFeed('my-article-slug', mockContent).replace(
+          '<link>https://username.medium.com/my-article-slug</link>',
+          '<link>https://different-link.com</link>'
+        );
+
+        global.fetch = vi.fn().mockResolvedValue({
+          ok: true,
+          text: () => Promise.resolve(rssXml),
+        });
+
+        const { fetchHtml } = await import('../../src/processing/fetcher.js');
+        const result = await fetchHtml(articleUrl);
+
+        expect(result).toContain(mockContent);
+      });
+    });
+
+    describe('error handling', () => {
+      it('should throw when RSS feed fetch fails', async () => {
+        const articleUrl = 'https://username.medium.com/test-article';
+
+        global.fetch = vi.fn().mockResolvedValue({
+          ok: false,
+          status: 503,
+        });
+
+        const { fetchHtml } = await import('../../src/processing/fetcher.js');
+
+        await expect(fetchHtml(articleUrl)).rejects.toThrow('Failed to fetch Medium RSS feed');
+        await expect(fetchHtml(articleUrl)).rejects.toThrow('503');
+      });
+
+      it('should throw when article not found in RSS feed', async () => {
+        const articleUrl = 'https://username.medium.com/nonexistent-article';
+        const mockContent =
+          '<div><p>Different article content that is long enough for validation.</p></div>';
+        const rssXml = createMockRssFeed('different-article-slug', mockContent);
+
+        global.fetch = vi.fn().mockResolvedValue({
+          ok: true,
+          text: () => Promise.resolve(rssXml),
+        });
+
+        const { fetchHtml } = await import('../../src/processing/fetcher.js');
+
+        await expect(fetchHtml(articleUrl)).rejects.toThrow('Article not found in Medium RSS feed');
+        await expect(fetchHtml(articleUrl)).rejects.toThrow('nonexistent-article');
+      });
+
+      it('should throw when RSS feed is empty', async () => {
+        const articleUrl = 'https://username.medium.com/test-article';
+        const emptyRss = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Empty Feed</title>
+  </channel>
+</rss>`;
+
+        global.fetch = vi.fn().mockResolvedValue({
+          ok: true,
+          text: () => Promise.resolve(emptyRss),
+        });
+
+        const { fetchHtml } = await import('../../src/processing/fetcher.js');
+
+        await expect(fetchHtml(articleUrl)).rejects.toThrow('No items found');
+      });
+
+      it('should throw when content:encoded is missing', async () => {
+        const articleUrl = 'https://username.medium.com/test-article';
+        const rssXml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <item>
+      <link>https://username.medium.com/test-article</link>
+    </item>
+  </channel>
+</rss>`;
+
+        global.fetch = vi.fn().mockResolvedValue({
+          ok: true,
+          text: () => Promise.resolve(rssXml),
+        });
+
+        const { fetchHtml } = await import('../../src/processing/fetcher.js');
+
+        await expect(fetchHtml(articleUrl)).rejects.toThrow('No content found in RSS item');
+      });
+
+      it('should throw when content is too short', async () => {
+        const articleUrl = 'https://username.medium.com/test-article';
+        const rssXml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/">
+  <channel>
+    <item>
+      <link>https://username.medium.com/test-article</link>
+      <content:encoded><![CDATA[<p>Short</p>]]></content:encoded>
+    </item>
+  </channel>
+</rss>`;
+
+        global.fetch = vi.fn().mockResolvedValue({
+          ok: true,
+          text: () => Promise.resolve(rssXml),
+        });
+
+        const { fetchHtml } = await import('../../src/processing/fetcher.js');
+
+        await expect(fetchHtml(articleUrl)).rejects.toThrow('No content found in RSS item');
+      });
+
+      it('should throw when XML is malformed', async () => {
+        const articleUrl = 'https://username.medium.com/test-article';
+        const malformedXml = '<rss><broken';
+
+        global.fetch = vi.fn().mockResolvedValue({
+          ok: true,
+          text: () => Promise.resolve(malformedXml),
+        });
+
+        const { fetchHtml } = await import('../../src/processing/fetcher.js');
+
+        // Should throw some error (either parse error or no items found)
+        await expect(fetchHtml(articleUrl)).rejects.toThrow();
+      });
+    });
+
+    describe('edge cases', () => {
+      it('should handle multiple items in RSS feed', async () => {
+        const articleUrl = 'https://username.medium.com/second-article';
+        const mockContent1 =
+          '<div><p>First article with more than enough content to pass all validation checks successfully.</p></div>';
+        const mockContent2 =
+          '<div><p>Second article with more than enough content to pass all validation checks successfully.</p></div>';
+
+        // Create RSS with multiple items manually
+        const rssXml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/">
+  <channel>
+    <title>Test Feed</title>
+    <item>
+      <title>First Article</title>
+      <link>https://username.medium.com/first-article</link>
+      <guid>https://username.medium.com/first-article</guid>
+      <content:encoded><![CDATA[${mockContent1}]]></content:encoded>
+    </item>
+    <item>
+      <title>Second Article</title>
+      <link>https://username.medium.com/second-article</link>
+      <guid>https://username.medium.com/second-article</guid>
+      <content:encoded><![CDATA[${mockContent2}]]></content:encoded>
+    </item>
+  </channel>
+</rss>`;
+
+        global.fetch = vi.fn().mockResolvedValue({
+          ok: true,
+          text: () => Promise.resolve(rssXml),
+        });
+
+        const { fetchHtml } = await import('../../src/processing/fetcher.js');
+        const result = await fetchHtml(articleUrl);
+
+        expect(result).toContain(mockContent2);
+        expect(result).not.toContain(mockContent1);
+      });
+
+      it('should handle URL with query parameters', async () => {
+        const articleUrl = 'https://username.medium.com/test-article?source=rss';
+        const mockContent =
+          '<div><p>Article content with more than sufficient length for validation to pass the minimum requirement.</p></div>';
+
+        global.fetch = vi.fn().mockResolvedValue({
+          ok: true,
+          text: () => Promise.resolve(createMockRssFeed('test-article', mockContent)),
+        });
+
+        const { fetchHtml } = await import('../../src/processing/fetcher.js');
+        const result = await fetchHtml(articleUrl);
+
+        expect(result).toContain(mockContent);
+      });
+
+      it('should handle URL with trailing slash', async () => {
+        const articleUrl = 'https://username.medium.com/test-article/';
+        const mockContent =
+          '<div><p>Article content with more than sufficient length for validation to pass the minimum requirement.</p></div>';
+
+        global.fetch = vi.fn().mockResolvedValue({
+          ok: true,
+          text: () => Promise.resolve(createMockRssFeed('test-article', mockContent)),
+        });
+
+        const { fetchHtml } = await import('../../src/processing/fetcher.js');
+        const result = await fetchHtml(articleUrl);
+
+        expect(result).toContain(mockContent);
+      });
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Detect Medium URLs (personal blogs and publications)
- Fetch and parse RSS feeds to extract article content
- Transparently handle Medium's Cloudflare blocking
- No changes needed to pipeline or other components

## Implementation Details
- Uses JSDOM for proper XML/RSS parsing (not regex)
- Handles XML namespaces correctly via element.localName
- Maintains simple fetchHtml interface unchanged
- Comprehensive test coverage (17 tests, all passing)

## Test Coverage
- URL detection for both Medium URL patterns
- RSS feed parsing and content extraction
- Article matching by slug in link and guid elements
- Error handling for missing articles, empty feeds, malformed XML
- Edge cases: query parameters, trailing slashes, multiple items

## Verification
All 101 tests pass including 17 new fetcher tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)